### PR TITLE
fixes #17; drop context around curl|wget matches

### DIFF
--- a/peframe/signatures/stringsmatch.json
+++ b/peframe/signatures/stringsmatch.json
@@ -5,7 +5,7 @@
 	"fuzzing": {
 		"String too long": "[A-Za-z0-9+/]{80,}",
 		"Possible encoded string": "(\\\\x[abcdef][abcdef|0-9]){3,}",
-		"Possible connections": ".*(curl|wget).*"
+		"Possible connections": "(curl|wget)"
 	},
 	"mutex": [
 		"CreateMutexA",


### PR DESCRIPTION
Closes #17 by dropping context around curl or wget matches.