### PR TITLE
Decode export function name

### DIFF
--- a/peframe/modules/directories.py
+++ b/peframe/modules/directories.py
@@ -42,7 +42,7 @@ def get_export(pe):
 		for exp in pe.DIRECTORY_ENTRY_EXPORT.symbols:
 			# No dll
 			address = pe.OPTIONAL_HEADER.ImageBase + exp.address
-			function = exp.name
+			function = exp.name.decode('ascii')
 			array.append({"offset": address, "function": function})
 	except:
 		pass


### PR DESCRIPTION
This fix is useful to avoid the following error:

```
Traceback (most recent call last):
  File "peframecli.py", line 296, in <module>
    print (json.dumps(result, sort_keys=True, indent=4))
  File "/usr/lib/python3.5/json/__init__.py", line 237, in dumps
    **kw).encode(obj)
  File "/usr/lib/python3.5/json/encoder.py", line 200, in encode
    chunks = list(chunks)
  File "/usr/lib/python3.5/json/encoder.py", line 429, in _iterencode
    yield from _iterencode_dict(o, _current_indent_level)
  File "/usr/lib/python3.5/json/encoder.py", line 403, in _iterencode_dict
    yield from chunks
  File "/usr/lib/python3.5/json/encoder.py", line 403, in _iterencode_dict
    yield from chunks
  File "/usr/lib/python3.5/json/encoder.py", line 403, in _iterencode_dict
    yield from chunks
  File "/usr/lib/python3.5/json/encoder.py", line 324, in _iterencode_list
    yield from chunks
  File "/usr/lib/python3.5/json/encoder.py", line 403, in _iterencode_dict
    yield from chunks
  File "/usr/lib/python3.5/json/encoder.py", line 436, in _iterencode
    o = _default(o)
  File "/usr/lib/python3.5/json/encoder.py", line 179, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: b'_MyFunc125@4' is not JSON serializable
```