### PR TITLE
Optional generation of the Yara ruleset

### DIFF
--- a/peframe/peframe.py
+++ b/peframe/peframe.py
@@ -103,7 +103,7 @@ def files_to_edit():
 	}
 	return path
 
-def analyze(filename):
+def analyze(filename, yaratest):
 	if not isfile(filename):
 		exit("File not found")
 
@@ -128,7 +128,7 @@ def analyze(filename):
 
 	fileinfo.update({"docinfo": docinfo})
 	fileinfo.update({"peinfo": peinfo})
-
+	
 	if ispe(filename):
 		pe = pefile.PE(filename)
 		peinfo.update({
@@ -145,11 +145,17 @@ def analyze(filename):
 			"metadata": meta.get(pe)
 			})
 		fileinfo.update({"peinfo": peinfo})
-		fileinfo.update({"yara_plugins": yara_check.yara_match_from_folder(path_to_file('pe', 'signatures/yara_plugins'), filename, ['antidebug_antivm.yar'])})
+		if yaratest:
+			fileinfo.update({"yara_plugins": yara_check.yara_match_from_folder(path_to_file('pe', 'signatures/yara_plugins'), filename, ['antidebug_antivm.yar'])})
+		else:
+			fileinfo.update({"yara_plugins": None})
 	else:
 		fileinfo.update({"docinfo": macro.get_result(filename)})
-		fileinfo.update({"yara_plugins": yara_check.yara_match_from_folder(path_to_file('doc', 'signatures/yara_plugins'), filename)})
-
+		if yaratest:
+			fileinfo.update({"yara_plugins": yara_check.yara_match_from_folder(path_to_file('doc', 'signatures/yara_plugins'), filename)})
+		else:
+			fileinfo.update({"yara_plugins": None})
+		
 	dt_end = get_datetime_now()
 
 	fileinfo.update({"time": str(dt_end - dt_start)})

--- a/peframe/peframecli.py
+++ b/peframe/peframecli.py
@@ -282,11 +282,17 @@ parser.add_argument("-i", "--interactive", help="join in interactive mode", acti
 parser.add_argument("-x", "--xorsearch", help="search xored string", required=False)
 parser.add_argument("-j", "--json", help="export short report in JSON", action='store_true', required=False)
 parser.add_argument("-s", "--strings", help="export all strings", action='store_true', required=False)
+parser.add_argument("-y", "--yara", help="generate yara ruleset", action='store_true', required=False)
 
 args = parser.parse_args()
 
 filename = args.file
-result = peframe.analyze(filename)
+
+if args.yara:
+	result = peframe.analyze(filename, True)
+else:
+	result = peframe.analyze(filename, False)
+	
 
 if args.xorsearch:
 	print (json.dumps(features.get_xor(filename, search_string=str.encode(args.xorsearch)), sort_keys=True, indent=4))


### PR DESCRIPTION
Often the generation of Yara ruleset it slows down a lot the generation of finael report. 

So I think the best solution is to make this generation optional.