### PR TITLE
Replacing deprecated alias tostring with tobytes

### DIFF
--- a/peframe/modules/features.py
+++ b/peframe/modules/features.py
@@ -18,7 +18,7 @@ def xor_delta(s, key_len = 1):
 		delta[x - key_len] ^= delta[x]
 		 
 	""" return the delta as a string """
-	return delta.tostring()[:-key_len]
+	return delta.tobytes()[:-key_len]
  
 def get_xor(filename, search_string=False):
 	xorsearch_custom = False


### PR DESCRIPTION
Tostring is now (python 3.9) a deprecated alias for tobytes. Since peframe requires python 3.6 (according to README) and tobytes has been introduced in python 3.2, there is no loss from removing the use of the alias in this project while upgrading python compatibility to 3.9 eventually.

Disclosure: I haven't fully tested it, you may want to build and run in a python 3.9 docker before merging, or set-up some automated tests using github actions. Can help on that if you want.